### PR TITLE
Fixed division by 0 check

### DIFF
--- a/lib/Operators.js
+++ b/lib/Operators.js
@@ -41,8 +41,8 @@ const Operators = {
 	"-": wrap((x, y) => y - x),
 	"*": wrap((x, y) => y * x),
 	",": wrap((x, y) => {
-		// Error out if y is 0
-		if (y === 0) {
+		// Error out if x is 0
+		if (x === 0) {
 			throw new Error("Division by zero");
 		}
 
@@ -50,8 +50,8 @@ const Operators = {
 		return y / x;
 	}),
 	"%": wrap((x, y) => {
-		// Error out if y is 0
-		if (y === 0) {
+		// Error out if x is 0
+		if (x === 0) {
 			throw new Error("Division by zero");
 		}
 


### PR DESCRIPTION
Div and mod operators were checking if the dividend was 0, not the divisor.

As a suggestion, would putting a test case of [0,5] be worthwhile in all operators tests?