### PR TITLE
Some tests were not checking if functions throw errors

### DIFF
--- a/test/FishStack.js
+++ b/test/FishStack.js
@@ -181,6 +181,7 @@ describe("Manipulating a FishStack", function () {
 
 				expect(() => stack["@"]()).to.throw();
 
+				stack.push(a);
 				stack.push(b);
 
 				expect(stack.length).to.equal(2);

--- a/test/FishStack.js
+++ b/test/FishStack.js
@@ -79,7 +79,7 @@ describe("Manipulating a FishStack", function () {
 
 		it("should refuse to take non-numbers", function () {
 			invalidTestdata.forEach((thing) => {
-				expect(() => stack.push(thing)).to.throw;
+				expect(() => stack.push(thing)).to.throw();
 			});
 		});
 
@@ -100,7 +100,7 @@ describe("Manipulating a FishStack", function () {
 		});
 
 		it("should throw when trying to pop again", function () {
-			expect(() => stack.pop()).to.throw;
+			expect(() => stack.pop()).to.throw();
 		});
 	});
 
@@ -115,7 +115,7 @@ describe("Manipulating a FishStack", function () {
 
 		describe("Duplicating top element", function () {
 			it("should throw when trying to duplicate the top value of an empty stack", function () {
-				expect(() => stack[":"]()).to.throw;
+				expect(() => stack[":"]()).to.throw();
 			});
 
 			it("should duplicate the top value", function () {
@@ -131,7 +131,7 @@ describe("Manipulating a FishStack", function () {
 
 		describe("Removing top value", function () {
 			it("should throw when trying to remove the top value of an empty stack", function () {
-				expect(() => stack["~"]()).to.throw;
+				expect(() => stack["~"]()).to.throw();
 			});
 
 			it("should remove the top value", function () {
@@ -151,13 +151,13 @@ describe("Manipulating a FishStack", function () {
 
 		describe("Swapping top two elements", function () {
 			it("should throw when trying to swap the top two elements when stack size is less than two", function () {
-				expect(() => stack["$"]()).to.throw;
+				expect(() => stack["$"]()).to.throw();
 
 				stack.push(a);
 
 				expect(stack.length).to.equal(1);
 
-				expect(() => stack["$"]()).to.throw;
+				expect(() => stack["$"]()).to.throw();
 			});
 
 			it("should swap the top two elements when size is two or more", function () {
@@ -173,19 +173,19 @@ describe("Manipulating a FishStack", function () {
 
 		describe("Swapping top three elements", function () {
 			it("should throw when trying to swap the top three elements when stack size is less than three", function () {
-				expect(() => stack["@"]()).to.throw;
+				expect(() => stack["@"]()).to.throw();
 
 				stack.push(a);
 
 				expect(stack.length).to.equal(1);
 
-				expect(() => stack["@"]()).to.throw;
+				expect(() => stack["@"]()).to.throw();
 
 				stack.push(b);
 
 				expect(stack.length).to.equal(2);
 
-				expect(() => stack["@"]()).to.throw;
+				expect(() => stack["@"]()).to.throw();
 			});
 
 			it("should swap the top two elements when size is two or more", function () {
@@ -284,7 +284,7 @@ describe("Manipulating a FishStack", function () {
 			});
 
 			it("should throw when empty and called on an empty stack", function () {
-				expect(() => stack["&"]()).to.throw;
+				expect(() => stack["&"]()).to.throw();
 			});
 		});
 
@@ -292,13 +292,13 @@ describe("Manipulating a FishStack", function () {
 
 		describe("Creating a new stack", function() {
 			it("should throw when the current stack is empty", function () {
-				expect(() => stack["["]()).to.throw;
+				expect(() => stack["["]()).to.throw();
 			});
 
 			it("should throw when there are not enough elements in the current stack", function () {
 				stack.push(42);
 
-				expect(() => stack["["]()).to.throw;
+				expect(() => stack["["]()).to.throw();
 
 			});
 

--- a/test/InstructionPointer.js
+++ b/test/InstructionPointer.js
@@ -78,7 +78,7 @@ describe("Changing direction", function () {
 
 	it("should fail when given something else", function () {
 		[1, {}, [], -8, "Blah"].forEach((thing) => {
-			expect(() => ip.changeDirection(thing)).to.throw;
+			expect(() => ip.changeDirection(thing)).to.throw();
 		});
 	});
 });
@@ -109,7 +109,7 @@ describe("Moving an instruction pointer", function () {
 	describe("Teleporting outside the program grid", function () {
 		it("should throw in all cases", function () {
 			invalidTeleportPoints.forEach(([x, y]) => {
-				expect(() => ip.teleport(x, y)).to.throw;
+				expect(() => ip.teleport(x, y)).to.throw();
 			});
 		});
 	});

--- a/test/Operators.js
+++ b/test/Operators.js
@@ -102,7 +102,7 @@ describe("Math operators", function () {
 		it("should complain if the top element is 0", function () {
 			stack.push(5);
 			stack.push(0);
-			expect(() => Operators[","](stack)).to.throw;
+			expect(() => Operators[","](stack)).to.throw();
 		});
 	});
 
@@ -120,7 +120,7 @@ describe("Math operators", function () {
 		it("should complain if the top element is 0", function () {
 			stack.push(5);
 			stack.push(0);
-			expect(() => Operators["%"](stack)).to.throw;
+			expect(() => Operators["%"](stack)).to.throw();
 		});
 	});
 

--- a/test/Stream.js
+++ b/test/Stream.js
@@ -63,7 +63,7 @@ describe("Reading from a stream", function () {
 	});
 
 	it("should throw when trying to read an empty stream", function () {
-		expect(() => stream.read()).to.throw;
+		expect(() => stream.read()).to.throw();
 	});
 });
 


### PR DESCRIPTION
According to the [Chai documentation](https://www.chaijs.com/api/bdd/), `expect(...).to.throw` should be like `expect(...).to.throw()` to check the function throws errors. Some of the tests lacked them so I added them.

Then, the test

```
Manipulating a FishStack
 Other operations
   Swapping top three elements
    1) should throw when trying to swap the top three elements when stack size is less than three
```

failed. I thought the test code was wrong and fixed it in https://github.com/Suppen/fish-interpreter/commit/1348322f759a7587b211865187479edbbab04328.