### PR TITLE
Fix handling of non-UNIX newlines and Unicode surrogates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage
 ```javascript
 const FishExecutor = require("fish-interpreter");
 
-const source = `"hello, world"r\
+const source = `"hello, world"rv
           o;!?l<`;
 
 const executor = new FishExecutor(source);

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ const source = `"hello, world"rv
 
 const executor = new FishExecutor(source);
 
+executor.intervalTime = 0;
+
 executor.onUpdate((e) => {
 	// `e` is the executor
 	if (e.hasTerminated) {

--- a/src/FishProgram.js
+++ b/src/FishProgram.js
@@ -44,7 +44,7 @@ class FishProgram {
 		 */
 		this._grid = source
 		  .split(/\r\n?|\n/)
-		  .map((line) => line.split(""))
+		  .map((line) => [...line])
 		  .map((line) => line.map((c) => c.charCodeAt(0)));
 
 		// Make sure the grid is nice to play with

--- a/src/FishProgram.js
+++ b/src/FishProgram.js
@@ -43,7 +43,7 @@ class FishProgram {
 		 * @private
 		 */
 		this._grid = source
-		  .split("\n")
+		  .split(/\r\n?|\n/)
 		  .map((line) => line.split(""))
 		  .map((line) => line.map((c) => c.charCodeAt(0)));
 


### PR DESCRIPTION
This PR makes console interpreter behavior on files with non-UNIX newlines match the behavior of online interpreter in Chrome/Firefox. Browsers replace \r\n and single \r with \n when pasting into textarea.

Also it fixes handling of Unicode characters beyond U+FFFF (they were treated as two characters before).

Also some improvements to README.md.